### PR TITLE
[INC-2231] Apply `--depth` to fetch as well

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -6,6 +6,6 @@ echo "Running git-shallow-clone-buildkite-plugin -- pre-checkout"
 
 DEPTH="${BUILDKITE_PLUGIN_GIT_SHALLOW_CLONE_DEPTH:-1}"
 export BUILDKITE_GIT_CLONE_FLAGS="-v --depth ${DEPTH}"
-#export BUILDKITE_GIT_FETCH_FLAGS="-v --prune --depth ${DEPTH}"
+export BUILDKITE_GIT_FETCH_FLAGS="-v --prune --depth ${DEPTH}"
 
 #export BUILDKITE_GIT_CLONE_FLAGS="-v --filter=blob:none"


### PR DESCRIPTION
Even with shallow clone, `git fetch` appears to do a lot more remote operations leading to timeouts. Although the name of the plugin doesn't mean shallow fetches, it seems reasonable to fetch only the current commit if there's an existing clone.

This ensures fetch also respect the depth being passed.